### PR TITLE
Save nine lamps start time in cookie

### DIFF
--- a/src/games/color_code_breaker/HeaderColorCodeGuesser.css
+++ b/src/games/color_code_breaker/HeaderColorCodeGuesser.css
@@ -32,5 +32,3 @@
   margin-bottom: 1rem;
   color: #555;
 }
-  
-    


### PR DESCRIPTION
A new cookie was implemented that tracks the start time of the 9 lamps game. 

By setting this cookie the remaining time to solve the puzzle is not reset after reloading the page or by navigation to another route. 
